### PR TITLE
Fix ArrayRef munging

### DIFF
--- a/lib/Data/NestedParams.pm
+++ b/lib/Data/NestedParams.pm
@@ -94,7 +94,7 @@ sub _collapse {
             _collapse($_, $r);
         }
     } elsif (!ref $v) {
-        $r->{$COLLAPSE_KEY} = $v;
+        push @$r, $COLLAPSE_KEY => $v;
     } else {
         my $ref = ref $v;
         Carp::confess("${ref} is not supported by collapse_nested_params");
@@ -108,7 +108,7 @@ sub collapse_nested_params {
     }
 
     local $COLLAPSE_KEY = '';
-    my $r = +{};
+    my $r = [];
     _collapse($dat, $r);
     return $r;
 }

--- a/t/03_collapse.t
+++ b/t/03_collapse.t
@@ -7,27 +7,40 @@ use Data::NestedParams;
 
 cmp_deeply(
     collapse_nested_params({ a => undef }),
-    { a => undef },
+    [ a => undef ],
 );
 
 cmp_deeply(
     collapse_nested_params({ a => 3 }),
-    { a => 3 },
+    [ a => 3 ],
 );
 
 cmp_deeply(
     collapse_nested_params({ a => [qw(x y z)] }),
-    { 'a[]' => 'x', 'a[]' => 'y', 'a[]' => 'z'},
+    [ 'a[]' => 'x', 'a[]' => 'y', 'a[]' => 'z' ],
 );
 
 cmp_deeply(
     collapse_nested_params({ a => { b => 3 } }),
-    { 'a[b]' => '3'},
+    [ 'a[b]' => '3' ],
 );
 
 cmp_deeply(
-    collapse_nested_params({'x' => {'y' => [{'z' => '1','w' => 'a'},{'z' => '2','w' => '3'}]}}),
-    {'x[y][][z]',1,'x[y][][w]','a','x[y][][z]',2,'x[y][][w]',3}
+    collapse_nested_params({
+        'x' => {
+            'y' => [
+                {'z' => '1','w' => 'a'},
+                {'z' => '2','w' => '3'}
+            ]
+        }
+    }),
+    # NOTE: Order here depends on perl hashing function
+    [
+        'x[y][][w]' => 'a',
+        'x[y][][z]' => 1,
+        'x[y][][w]' => 3,
+        'x[y][][z]' => 2,
+    ]
 );
 
 done_testing;


### PR DESCRIPTION
Return an ArrayRef instead of a HashRef so that arrays aren't munged.

This addresses issue #1.
