### PR TITLE
make collapse_nested_params support JSON boolean values

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Perl extension Data-NestedParams
 
 {{$NEXT}}
 
+0.08 2015-11-04T13:00:00Z
+
+    - Collapse now works with JSON boolean values.
+      (plainblackguy)
+
 0.07 2014-07-27T23:09:34Z
 
     - Allow numeric characters in hash key.

--- a/META.json
+++ b/META.json
@@ -49,7 +49,8 @@
          "requires" : {
             "Test::Base::Less" : "0.12",
             "Test::Deep" : "0",
-            "Test::More" : "0.98"
+            "Test::More" : "0.98",
+	    "JSON" : "0"
          }
       }
    },

--- a/lib/Data/NestedParams.pm
+++ b/lib/Data/NestedParams.pm
@@ -3,7 +3,7 @@ use 5.008005;
 use strict;
 use warnings FATAL => 'all';
 
-our $VERSION = "0.07";
+our $VERSION = "0.08";
 
 use parent qw(Exporter);
 
@@ -93,6 +93,8 @@ sub _collapse {
             local $COLLAPSE_KEY = $COLLAPSE_KEY . '[]';
             _collapse($_, $r);
         }
+    } elsif (ref $v eq 'JSON::XS::Boolean' || ref $v eq 'JSON::PP::Boolean') { # could use JSON::is_bool, but that would require extra dependency
+        $r->{$COLLAPSE_KEY} = $v;
     } elsif (!ref $v) {
         $r->{$COLLAPSE_KEY} = $v;
     } else {

--- a/t/03_collapse.t
+++ b/t/03_collapse.t
@@ -4,6 +4,7 @@ use utf8;
 use Test::More;
 use Test::Deep;
 use Data::NestedParams;
+use JSON;
 
 cmp_deeply(
     collapse_nested_params({ a => undef }),
@@ -28,6 +29,11 @@ cmp_deeply(
 cmp_deeply(
     collapse_nested_params({'x' => {'y' => [{'z' => '1','w' => 'a'},{'z' => '2','w' => '3'}]}}),
     {'x[y][][z]',1,'x[y][][w]','a','x[y][][z]',2,'x[y][][w]',3}
+);
+
+cmp_deeply(
+    collapse_nested_params({ a => { b => 3 }, c => JSON::true }),
+    { 'a[b]' => '3', c => JSON::true },
 );
 
 done_testing;


### PR DESCRIPTION
Some APIs like stripe.com have you post JSON booleans in their nesting. In those situation 1/0 isn't good enough, and this patch allows for it to work without disrupting anything else. I hope you'll accept it.

I wrote a test to prove this works. I chose not to use the JSON module inside of Data::NestedParams because I didn't think you'd want an extra dependency. 
